### PR TITLE
Remove need of project.afterEvaluate() and add generateJavadoc macro task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ local.properties
 
 .idea/
 *.iml
+.gradletasknamecache

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ apply plugin: "com.vanniktech.android.javadoc"
 ./gradlew generateReleaseJavadoc
 ```
 
+or to run javadoc task for all variants :
+
+```gradle
+./gradlew generateJavadoc
+```
+
 **HTML reports**
 
 ```
@@ -57,6 +63,12 @@ apply plugin: "com.vanniktech.android.javadoc"
 ```
 ./gradlew generateDebugJavadocJar
 ./gradlew generateReleaseJavadocJar
+```
+
+or to run javadoc archive task for all variants :
+
+```gradle
+./gradlew generateJavadocJar
 ```
 
 ## Customize Plugin

--- a/build.gradle
+++ b/build.gradle
@@ -1,21 +1,11 @@
-buildscript {
-  repositories {
-    jcenter()
-    maven { url "https://plugins.gradle.org/m2/" }
-  }
-
-  dependencies {
-    classpath 'com.gradle.publish:plugin-publish-plugin:0.9.9'
-    classpath 'com.github.ben-manes:gradle-versions-plugin:0.17.0'
-    classpath 'com.vanniktech:gradle-android-junit-jacoco-plugin:0.11.0'
-  }
+plugins {
+  id "groovy"
+  id "java"
+  id 'maven-publish'
+  id 'com.gradle.plugin-publish' version '0.9.9'
+  id "com.vanniktech.android.junit.jacoco" version "0.11.0"
+  id "com.github.ben-manes.versions" version "0.17.0"
 }
-
-apply plugin: 'groovy'
-apply plugin: 'java'
-apply plugin: 'com.github.ben-manes.versions'
-apply plugin: 'com.gradle.plugin-publish'
-apply plugin: 'com.vanniktech.android.junit.jacoco'
 
 repositories {
   jcenter()
@@ -25,8 +15,10 @@ repositories {
 dependencies {
   compile gradleApi()
   compile localGroovy()
-  compile 'com.android.tools.build:gradle:3.0.1'
 
+  compileOnly 'com.android.tools.build:gradle:3.1.2'
+
+  testCompile 'com.android.tools.build:gradle:3.1.2'
   testCompile 'junit:junit:4.12'
 }
 

--- a/src/main/groovy/com/vanniktech/android/javadoc/extensions/AndroidJavadocExtension.groovy
+++ b/src/main/groovy/com/vanniktech/android/javadoc/extensions/AndroidJavadocExtension.groovy
@@ -2,7 +2,7 @@ package com.vanniktech.android.javadoc.extensions
 
 import org.gradle.api.Project
 
-public class AndroidJavadocExtension {
+class AndroidJavadocExtension {
     /**
      * Closure used for filter some variant out
      */


### PR DESCRIPTION
Hi,

I have made some changes to javadoc plugin. Could please review these changes and make some comments about it ?

**build.gradle**

I am now using plugins dsl to ease read. 

I also changed the dependency to android gradle plugin with `compileOnly` configuration. This prevents this lib to be added to dependencies in pom.xml

**Generation.groovy**

I choose to not add the plugin to child projects in case it is added to a root project of multi module build.  Please advise me if it is a bad idea. 

I also removed the `afterEvaluate` closure in favor of `variant.all` ones. 

I am also creating root task named `generateJavadoc`. Running this task will run javadoc task for all variants. The same for the Jar. 

Last but not least : this plugin can be added before android plugin is applied.

Thanks

